### PR TITLE
Clarify how to make rollout restarts work

### DIFF
--- a/content/en/docs/faq.md
+++ b/content/en/docs/faq.md
@@ -191,11 +191,19 @@ In order for Flux to preserve fields added with kubectl, for example a label or 
 you have to specify a field manager named `flux-client-side-apply` e.g.:
 
 ```yaml
-kubectl annotate --field-manager=flux-client-side-apply 
+kubectl --field-manager=flux-client-side-apply label ...
 ```
 
 Note that fields specified in Git will always be overridden, the above procedure works only for
 adding new fields that don't overlap with the desired state.
+
+Rollout restarts add a "restartedAt" annotation, which flux will remove, re-deploying the pods.
+To complete a rollout restart successfully, use the `flux-client-side-apply` field manager e.g.:
+
+```yaml
+kubectl --field-manager=flux-client-side-apply rollout restart ...
+```
+
 
 ### What is the behavior of Kustomize used by Flux?
 


### PR DESCRIPTION
... using the flux-client-side-apply field manager. I also changed the example to be a label edit for extra clarity.

Signed-off-by: annaken <annaken@wgtwo.com>